### PR TITLE
Remove unnecessary code from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,112 +3,31 @@
 import os
 import platform
 from distutils.core import Extension
-from pathlib import Path
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
-
-work_dir = os.path.dirname(os.path.realpath(__file__))
-mod_dir = os.path.join(work_dir, 'src', 'confluent_kafka')
-ext_dir = os.path.join(mod_dir, 'src')
-
-INSTALL_REQUIRES = [
-    'futures;python_version<"3.2"',
-    'enum34;python_version<"3.4"',
-]
-
-TEST_REQUIRES = [
-    'pytest==4.6.4;python_version<"3.0"',
-    'pytest;python_version>="3.0"',
-    'pytest-timeout',
-    'flake8'
-]
-
-DOC_REQUIRES = ['sphinx', 'sphinx-rtd-theme']
-
-SCHEMA_REGISTRY_REQUIRES = ['requests']
-
-AVRO_REQUIRES = ['fastavro>=0.23.0,<1.0;python_version<"3.0"',
-                 'fastavro>=1.0;python_version>"3.0"',
-                 'avro>=1.11.1,<2',
-                 ] + SCHEMA_REGISTRY_REQUIRES
-
-JSON_REQUIRES = ['pyrsistent==0.16.1;python_version<"3.0"',
-                 'pyrsistent;python_version>"3.0"',
-                 'jsonschema'] + SCHEMA_REGISTRY_REQUIRES
-
-PROTO_REQUIRES = ['protobuf'] + SCHEMA_REGISTRY_REQUIRES
-
-# On Un*x the library is linked as -lrdkafka,
-# while on windows we need the full librdkafka name.
-if platform.system() == 'Windows':
-    librdkafka_libname = 'librdkafka'
+if platform.system() == "Windows":
+    librdkafka_libname = "librdkafka"
 else:
-    librdkafka_libname = 'rdkafka'
+    librdkafka_libname = "rdkafka"
 
 
-cimpl_dir_prefix = "src/confluent_kafka/src" 
+cimpl_dir_prefix = "src/confluent_kafka/src"
 
-module = Extension('confluent_kafka.cimpl',
-                   libraries=[librdkafka_libname],
-                   sources=[os.path.join(cimpl_dir_prefix, 'confluent_kafka.c'),
-                            os.path.join(cimpl_dir_prefix, 'Producer.c'),
-                            os.path.join(cimpl_dir_prefix, 'Consumer.c'),
-                            os.path.join(cimpl_dir_prefix, 'Metadata.c'),
-                            os.path.join(cimpl_dir_prefix, 'AdminTypes.c'),
-                            os.path.join(cimpl_dir_prefix, 'Admin.c')])
-                #    sources=[os.path.join(ext_dir, 'confluent_kafka.c'),
-                #             os.path.join(ext_dir, 'Producer.c'),
-                #             os.path.join(ext_dir, 'Consumer.c'),
-                #             os.path.join(ext_dir, 'Metadata.c'),
-                #             os.path.join(ext_dir, 'AdminTypes.c'),
-                #             os.path.join(ext_dir, 'Admin.c')])
+module = Extension(
+    "confluent_kafka.cimpl",
+    libraries=[librdkafka_libname],
+    sources=[
+        os.path.join(cimpl_dir_prefix, "confluent_kafka.c"),
+        os.path.join(cimpl_dir_prefix, "Producer.c"),
+        os.path.join(cimpl_dir_prefix, "Consumer.c"),
+        os.path.join(cimpl_dir_prefix, "Metadata.c"),
+        os.path.join(cimpl_dir_prefix, "AdminTypes.c"),
+        os.path.join(cimpl_dir_prefix, "Admin.c"),
+    ],
+)
 
 
-def get_install_requirements(path):
-    content = open(os.path.join(os.path.dirname(__file__), path)).read()
-    return [
-        req
-        for req in content.split("\n")
-        if req != '' and not req.startswith('#')
-    ]
-
-
-trove_classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-]
-
-
-setup(name='superstream-confluent-kafka',
-
-      # Make sure to bump CFL_VERSION* in confluent_kafka/src/confluent_kafka.h
-      # and version in docs/conf.py.
-      version='2.4.0',
-      description='Confluent\'s Python client for Apache Kafka',
-      author='Superstream Labs',
-      author_email='support@superstream.ai',
-      url='https://github.com/superstreamlabs/confluent-kafka-python.git',
-
-      ext_modules=[module],
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-    #   data_files=[('', [os.path.join(cimpl_dir_prefix, 'LICENSE.txt')])],
-      data_files=[('', ['LICENSE.txt'])],
-      install_requires=INSTALL_REQUIRES,
-      classifiers=trove_classifiers,
-      extras_require={
-          'schema-registry': SCHEMA_REGISTRY_REQUIRES,
-          'avro': AVRO_REQUIRES,
-          'json': JSON_REQUIRES,
-          'protobuf': PROTO_REQUIRES,
-          'dev': TEST_REQUIRES + AVRO_REQUIRES,
-          'doc': DOC_REQUIRES + AVRO_REQUIRES
-      })
+setup(
+    ext_modules=[module],
+)


### PR DESCRIPTION
Package info, metadata, deps,... are moved from `setup.py` to `pyproject.toml`. The `setup.py` is used to configures C extension modules in the Python package build process.