### PR TITLE
Superstream standard output based on `SUPERSTREAM_DEBUG`, and modify configuration update process

### DIFF
--- a/src/confluent_kafka/superstream/constants.py
+++ b/src/confluent_kafka/superstream/constants.py
@@ -22,8 +22,8 @@ class SuperstreamKeys:
 
 
 class SuperstreamValues:
-    MAX_TIME_WAIT_CAN_START = 60 * 10
-    DEFAULT_SUPERSTREAM_TIMEOUT = 3000
+    MAX_TIME_WAIT_CAN_START = 60 * 10 # in seconds
+    DEFAULT_SUPERSTREAM_TIMEOUT = 3000 # in milliseconds
     OPTIMIZED_CONFIGURATION_KEY = "optimized_configuration"
     INTERNAL_USERNAME = "superstream_internal"
 

--- a/src/confluent_kafka/superstream/consumer_interceptor.py
+++ b/src/confluent_kafka/superstream/consumer_interceptor.py
@@ -45,8 +45,7 @@ class SuperstreamConsumerInterceptor:
         self.__update_topic_partitions(message)
         try:
             return asyncio.run(self.__deserialize(message))
-        except Exception as e:
-            print(f"error deserializing message: {e!s}")
+        except Exception:
             return message
 
     async def __deserialize(self, message: Any) -> Any:
@@ -90,7 +89,6 @@ class SuperstreamConsumerInterceptor:
             descriptor = superstream.consumer_proto_desc_map.get(schema_id)
             if not descriptor:
                 await superstream.handle_error(f"error getting schema with id: {schema_id}")
-                print("superstream: shcema not found")
                 return message
 
         try:

--- a/src/confluent_kafka/superstream/core.py
+++ b/src/confluent_kafka/superstream/core.py
@@ -679,8 +679,7 @@ class Superstream:
         subscription = None
         try:
             subscription = await self.broker_connection.subscribe(subject, cb=start_cb)
-            # await asyncio.wait_for(is_started(), timeout=SuperstreamValues.MAX_TIME_WAIT_CAN_START)
-            await asyncio.wait_for(is_started(), timeout=60)
+            await asyncio.wait_for(is_started(), timeout=SuperstreamValues.MAX_TIME_WAIT_CAN_START)
             if not self.can_start:
                 self.std.error(
                     "superstream: Could not connect to superstream for 10 minutes."

--- a/src/confluent_kafka/superstream/core.py
+++ b/src/confluent_kafka/superstream/core.py
@@ -755,7 +755,7 @@ class Superstream:
             )
 
         except Exception as e:
-            print(f"superstream: Could not subscribe to updates: {e}")
+            self.std.error(f"superstream: Could not subscribe to updates: {e}")
 
     def update_topic_partitions(self, topic: str, partition: int):
         self.topic_partitions[topic] = self.topic_partitions.get(topic, [])

--- a/src/confluent_kafka/superstream/producer_interceptor.py
+++ b/src/confluent_kafka/superstream/producer_interceptor.py
@@ -113,10 +113,6 @@ class SuperstreamProducerInterceptor:
 
         self._producer_handler(*args, **kwargs)
 
-    def update_stats(self, state: Dict[str, Any]):
-        print(state)
-        # raise NotImplementedError
-
     def _serialize(self, json_msg: str) -> Union[bytes, Dict[str, Any]]:
         superstream: Superstream = self._superstream_config_.get(
             SuperstreamKeys.CONNECTION

--- a/src/confluent_kafka/superstream/std.py
+++ b/src/confluent_kafka/superstream/std.py
@@ -1,6 +1,6 @@
 import io
 import sys
-from typing import AnyStr
+from typing import AnyStr, List
 
 from confluent_kafka.superstream.constants import EnvVars
 
@@ -13,58 +13,37 @@ class SuperstreamStd:
             cls._instance = super(SuperstreamStd, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, disable_stdout: bool = False, disable_stderr: bool = False):
+    def __init__(self):
         if not hasattr(self, "_initialized"):
-            disable_stdout, disable_stderr = SuperstreamStd.check_stdout_env_var()
-            self._is_stdout_disabled = disable_stdout
-            self._is_std_err_disabled = disable_stderr
+            enable_stdout, enable_stderr = SuperstreamStd.check_stdout_env_var()
 
-            self.stdout = sys.stdout
-            self.stderr = sys.stderr
-
-            self.superstream_stdout = io.StringIO()
-            self.superstream_stderr = io.StringIO()
-
-            # sys.stdout = self.superstream_stdout
-            # sys.stderr = self.superstream_stderr
+            self.stdout = sys.stdout if enable_stdout else io.StringIO()
+            self.stderr = sys.stderr if enable_stderr else io.StringIO()
 
             self._initialized = True
 
-    def write(self, msg:AnyStr, **kwargs):
-        if self._is_stdout_disabled:
-            return
-        msg = ''.join(map(str, msg)) + '\n'
-        self.stdout.write(msg, **kwargs)
+    def write(self, s: AnyStr, **kwargs):
+        if not isinstance(s, str):
+            s = f"{s}\n"
+        self.stdout.write(s, **kwargs)
 
-    def writelines(self, *args, **kwargs):
-        if self._is_stdout_disabled:
-            return
-        self.stdout.writelines(*args, **kwargs)
+    def writelines(self, lines: List[AnyStr], **kwargs):
+        self.stdout.writelines(lines, **kwargs)
 
-    def error(self, msg:AnyStr, **kwargs):
-        if self._is_std_err_disabled:
-            return
-        msg = ''.join(map(str, msg)) + '\n'
-        self.stderr.write(msg, **kwargs)
+    def error(self, s: AnyStr, **kwargs):
+        if not isinstance(s, str):
+            s = f"{s}\n"
+        self.stderr.write(s, **kwargs)
 
     def errorlines(self, *args, **kwargs):
-        if self._is_std_err_disabled:
-            return
         self.stderr.writelines(*args, **kwargs)
-
-    def flush(self):
-        self.stdout.flush()
-        self.stderr.flush()
-
-        sys.stdout = self.original_stdout
-        sys.stderr = self.original_stderr
 
     @staticmethod
     def check_stdout_env_var():
         if EnvVars.SUPERSTREAM_DEBUG:
-            is_stdout_disabled = True
-            is_std_err_disabled = True
+            enable_stdout = True
+            enable_stderr = True
         else:
-            is_stdout_disabled = False
-            is_std_err_disabled = False
-        return is_stdout_disabled, is_std_err_disabled
+            enable_stdout = False
+            enable_stderr = False
+        return enable_stdout, enable_stderr

--- a/src/confluent_kafka/superstream/std.py
+++ b/src/confluent_kafka/superstream/std.py
@@ -23,7 +23,7 @@ class SuperstreamStd:
             self._initialized = True
 
     def write(self, s: AnyStr, **kwargs):
-        if not isinstance(s, str):
+        if isinstance(s, str):
             s = f"{s}\n"
         self.stdout.write(s, **kwargs)
 
@@ -31,7 +31,7 @@ class SuperstreamStd:
         self.stdout.writelines(lines, **kwargs)
 
     def error(self, s: AnyStr, **kwargs):
-        if not isinstance(s, str):
+        if isinstance(s, str):
             s = f"{s}\n"
         self.stderr.write(s, **kwargs)
 


### PR DESCRIPTION
- [x] __SUPERSTREAM_DEBUG__ - Default is `false`, and no logs will be printed from Superstream. Set this environment variable to `true` to enable Superstream logging.
- [x] __Configuration Update Process__ - When updating the configuration, it occurs twice: once at registration and again after retrieving the full config. During the second update, all values should be included, but any values present in the first config should override those in the second.